### PR TITLE
Replace http with https

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Add a json configuration file like this one:
     "InstanceID": "YOUR DEVICE",
     "HistoryProcessingInterval": 600,
     "LocalDBPath": "pastpath.db",
+    "Search": {
+        "ReplaceHTTPWithHTTPS": true
+    },
     "Browsers": [
         {
             "Name": "chrome",

--- a/handlers.go
+++ b/handlers.go
@@ -15,7 +15,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, "static/index.html")
 }
 
-func searchHandler(db *sql.DB, w http.ResponseWriter, r *http.Request) {
+func searchHandler(db *sql.DB, replaceHTTPWithHTTPS bool, w http.ResponseWriter, r *http.Request) {
 	searchTerm := r.URL.Query().Get("term")
 	searchTerms := strings.Fields(searchTerm)
 	var queryConditions []string
@@ -26,8 +26,44 @@ func searchHandler(db *sql.DB, w http.ResponseWriter, r *http.Request) {
 		queryConditions = append(queryConditions, "(LOWER(title) LIKE ? OR LOWER(url) LIKE ?)")
 		queryParameters = append(queryParameters, term, term)
 	}
+	var query string
 	// Some times the title changes for the url, so here the latest title is selected for each url.
-	query := `
+	if replaceHTTPWithHTTPS {
+		query = `WITH url_cte AS (
+					SELECT
+						(
+							SELECT COALESCE(title, '')
+							FROM urls AS latest
+							WHERE latest.url = urls.url
+							ORDER BY last_visit_time DESC
+							LIMIT 1
+						) AS title,
+						url,
+						REPLACE(url, 'http://', 'https://') as https_url,
+						MAX(last_visit_time) AS last_visit_time,
+						SUM(visit_count) AS visit_count
+					FROM urls
+					WHERE ` + strings.Join(queryConditions, " AND ") + `
+					GROUP BY url
+					ORDER BY LENGTH(url) ASC
+					LIMIT 40
+		)
+	
+		SELECT title,
+		CASE WHEN url != a.https_url AND url_count>1 then a.https_url ELSE url END as url, 
+		MAX(last_visit_time) AS last_visit_time,
+		SUM(visit_count) AS visit_count
+		FROM url_cte	a
+		LEFT JOIN (SELECT COUNT(DISTINCT url) as url_count, https_url
+								FROM url_cte
+								GROUP BY https_url
+								) AS  b on a.https_url=b.https_url
+		GROUP BY CASE WHEN url != a.https_url AND url_count>1 then a.https_url ELSE url END 
+		ORDER BY LENGTH(CASE WHEN url != a.https_url AND url_count>1 then a.https_url ELSE url END ) ASC
+		LIMIT 20;`
+	} else {
+
+		query = `
 		SELECT
 			(
 				SELECT COALESCE(title, '')
@@ -45,7 +81,7 @@ func searchHandler(db *sql.DB, w http.ResponseWriter, r *http.Request) {
 		ORDER BY LENGTH(url) ASC
 		LIMIT 20;
     `
-
+	}
 	rows, err := db.Query(query, queryParameters...)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/import.go
+++ b/import.go
@@ -31,11 +31,11 @@ func updateBrowsersMetadata(b Browsers) Browsers {
 		case "chrome":
 			b[i].Query = "SELECT url, title, visit_count, last_visit_time FROM urls ORDER BY last_visit_time DESC"
 			b[i].TimestampConverter = convertChromeTimestamp
-	
+
 		case "firefox":
 			b[i].Query = "SELECT url, COALESCE(title,'') AS title, visit_count, COALESCE(last_visit_date,0) AS last_visit_date FROM moz_places ORDER BY last_visit_date DESC"
 			b[i].TimestampConverter = convertFirefoxTimestamp
-	
+
 		default:
 			log.Printf("Browser not supported: %s", b[i].Name)
 		}

--- a/main.go
+++ b/main.go
@@ -23,8 +23,8 @@ type Config struct {
 	InstanceID                       string   `json:"InstanceID"`
 	HistoryProcessingIntervalSeconds int      `json:"HistoryProcessingIntervalSeconds"`
 	LocalDBPath                      string   `json:"LocalDBPath"`
-	Browsers                         Browsers `json:"Browsers"`
 	Search                           Search   `json:"Search"`
+	Browsers                         Browsers `json:"Browsers"`
 }
 
 type Search struct {

--- a/main.go
+++ b/main.go
@@ -18,12 +18,17 @@ import (
 )
 
 type Config struct {
-	ServerPort                       int16   `json:"ServerPort"`
+	ServerPort                       int16    `json:"ServerPort"`
 	TmpDir                           string   `json:"TmpDir"`
 	InstanceID                       string   `json:"InstanceID"`
 	HistoryProcessingIntervalSeconds int      `json:"HistoryProcessingIntervalSeconds"`
 	LocalDBPath                      string   `json:"LocalDBPath"`
 	Browsers                         Browsers `json:"Browsers"`
+	Search                           Search   `json:"Search"`
+}
+
+type Search struct {
+	ReplaceHTTPWithHTTPS bool `json:"ReplaceHTTPWithHTTPS"`
 }
 
 func NewDefaultConfig() *Config {
@@ -32,6 +37,7 @@ func NewDefaultConfig() *Config {
 		TmpDir:                           ".tmp",
 		HistoryProcessingIntervalSeconds: 600,
 		LocalDBPath:                      "pastpath.db",
+		Search:                           Search{ReplaceHTTPWithHTTPS: true},
 	}
 }
 
@@ -85,7 +91,7 @@ func main() {
 	// Define routes
 	http.HandleFunc("/", indexHandler)
 	http.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) {
-		searchHandler(db, w, r)
+		searchHandler(db, cfg.Search.ReplaceHTTPWithHTTPS, w, r)
 	})
 	http.HandleFunc("/last-updated", func(w http.ResponseWriter, r *http.Request) {
 		lastUpdatedHandler(db, w, r)
@@ -94,7 +100,7 @@ func main() {
 
 	// Start HTTP server
 	log.Printf("Starting server on port %d", cfg.ServerPort)
-	srv := &http.Server{Addr: fmt.Sprintf(":%d",cfg.ServerPort)}
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", cfg.ServerPort)}
 	go func() {
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 			log.Fatalf("HTTP server ListenAndServe: %v", err)
@@ -121,7 +127,7 @@ func loadConfig(configFile string) (*Config, error) {
 
 	file, err := os.Open(configFile)
 	if err != nil {
-		return nil, errors.Wrapf(err,"Unable to open config file: %s", configFile)
+		return nil, errors.Wrapf(err, "Unable to open config file: %s", configFile)
 	}
 	defer file.Close()
 


### PR DESCRIPTION
Replacing http with https makes sense in most cases, also as browser or web server will redirect to https. But you may have history on localhost, IPs or even hostnames, that for one reason or another is supposed to be http, so this PR introduces a replacement that checks if there is also history on https and is so replace http with https.
So this way, if we only have history on http, it will stay http, if we have history on https, http entries will be grouped under https.

This increases query time (probably around 2x) so this behaviour is optional through config