### PR TITLE
Inital working version for firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ Path to history databases for your OS and browser is easy to find on the web, th
 
 The search used is a basic SQL `like` based approach, with each space-separated term appended as it's own like. This has proven to provide fast and reliable results, even if it does not provide a fuzzy search option. Experiments with fzf did not show great potential.
 
+## OpenSearch (experimental)
+
+Firefox (and maybe other browers, not Chrome) supports searching in omnibox (address bar) through custom OpenSearch compatible search engine. **pastpath** has experimental support for using this feature in Firefox, such that you can search history in your omnibox. These steps roughly outlines how to enable this:
+
+1) Check `opensearch.xml` is configured with correct port
+2) Go localhost:10000, add **pastpath**v as search engine in top right corner search bar (it is a bit tricky to find the button)
+3) Set **pastpath** to default search engine in settings
+4) Now you can get suggestions. It shows up as "title (url)". On `enter` it redirects to url. If url is not there, it redirect to google search.
+
+Experience is not as good and rich as **pastpath** UI.
+
 ## Roadmap
 
 Items on top of the TODO list:

--- a/handlers.go
+++ b/handlers.go
@@ -3,9 +3,19 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/pkg/errors"
 )
+
+type searchResult struct {
+	Title         string `json:"title"`
+	URL           string `json:"url"`
+	LastVisitTime int    `json:"last_visit_time"`
+	VisitCount    int    `json:"visit_count"`
+}
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
@@ -17,6 +27,35 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 
 func searchHandler(db *sql.DB, replaceHTTPWithHTTPS bool, w http.ResponseWriter, r *http.Request) {
 	searchTerm := r.URL.Query().Get("term")
+
+	searchResults, err := queryHistory(db, replaceHTTPWithHTTPS, searchTerm)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(searchResults)
+}
+
+func lastUpdatedHandler(db *sql.DB, w http.ResponseWriter, r *http.Request) {
+	row := db.QueryRow("SELECT MAX(timestamp) as last_timestamp FROM last_run")
+
+	var lastTimestamp sql.NullInt64
+	if err := row.Scan(&lastTimestamp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if lastTimestamp.Valid {
+		json.NewEncoder(w).Encode(map[string]interface{}{"last_timestamp": lastTimestamp.Int64, "build_version": BuildVersion})
+	} else {
+		json.NewEncoder(w).Encode(map[string]interface{}{"last_timestamp": nil, "build_version": BuildVersion})
+	}
+}
+
+func queryHistory(db *sql.DB, replaceHTTPWithHTTPS bool, searchTerm string) ([]searchResult, error) {
 	searchTerms := strings.Fields(searchTerm)
 	var queryConditions []string
 	var queryParameters []interface{}
@@ -84,44 +123,78 @@ func searchHandler(db *sql.DB, replaceHTTPWithHTTPS bool, w http.ResponseWriter,
 	}
 	rows, err := db.Query(query, queryParameters...)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, errors.Wrap(err, "Unable to create query")
 	}
 	defer rows.Close()
 
-	var entries []map[string]interface{}
+	var searchResults []searchResult
 	for rows.Next() {
-		var title, url string
-		var lastVisitTime, visitCount int
-		if err := rows.Scan(&title, &url, &lastVisitTime, &visitCount); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+		var result searchResult
+		if err := rows.Scan(&result.Title, &result.URL, &result.LastVisitTime, &result.VisitCount); err != nil {
+			return nil, errors.Wrap(err, "Unable to scan row")
 		}
-		entries = append(entries, map[string]interface{}{
-			"title":           title,
-			"url":             url,
-			"last_visit_time": lastVisitTime,
-			"visit_count":     visitCount,
-		})
+		searchResults = append(searchResults, result)
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(entries)
+	return searchResults, nil
 }
 
-func lastUpdatedHandler(db *sql.DB, w http.ResponseWriter, r *http.Request) {
-	row := db.QueryRow("SELECT MAX(timestamp) as last_timestamp FROM last_run")
+func searchSuggestionsHandler(db *sql.DB, replaceHTTPWithHTTPS bool, w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query().Get("term")
+	if query == "" {
+		http.Error(w, "Query parameter 'term' is missing", http.StatusBadRequest)
+		return
+	}
 
-	var lastTimestamp sql.NullInt64
-	if err := row.Scan(&lastTimestamp); err != nil {
+	searchResults, err := queryHistory(db, replaceHTTPWithHTTPS, query)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	_ = searchResults
+
+	var suggestions []string
+	// var descriptions []string
+	// var urls []string
+	limit := 5
+	for i, s := range searchResults {
+		suggestions = append(suggestions, fmt.Sprintf("%s (%s)", s.Title, s.URL))
+		// suggestions = append(suggestions, s.Title)
+		// descriptions = append(descriptions, s.Title)
+		// urls = append(urls, s.URL)
+		if i == limit -1 {
+			break
+		}
+	}
+
+	//response := []interface{}{query, suggestions, descriptions, urls}
+	response := []interface{}{query, suggestions}
+
 	w.Header().Set("Content-Type", "application/json")
-	if lastTimestamp.Valid {
-		json.NewEncoder(w).Encode(map[string]interface{}{"last_timestamp": lastTimestamp.Int64, "build_version": BuildVersion})
-	} else {
-		json.NewEncoder(w).Encode(map[string]interface{}{"last_timestamp": nil, "build_version": BuildVersion})
+
+	err = json.NewEncoder(w).Encode(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
+
+func redirectHandler(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query().Get("term")
+	if query == "" {
+		http.Error(w, "Query parameter 'term' is missing", http.StatusBadRequest)
+		return
+	}
+
+	lastOpenParen := strings.LastIndex(query, " (")
+	if lastOpenParen == -1 {
+		http.Redirect(w, r, "https://google.com/search?q="+query, http.StatusMovedPermanently)
+	}
+
+	url := query[lastOpenParen+2 : len(query)-1]
+
+
+	http.Redirect(w, r, url, http.StatusMovedPermanently)
+}
+
+
+

--- a/main.go
+++ b/main.go
@@ -93,6 +93,12 @@ func main() {
 	http.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) {
 		searchHandler(db, cfg.Search.ReplaceHTTPWithHTTPS, w, r)
 	})
+	http.HandleFunc("/opensearch", func(w http.ResponseWriter, r *http.Request) {
+		searchSuggestionsHandler(db, cfg.Search.ReplaceHTTPWithHTTPS, w, r)
+	})
+	http.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+		redirectHandler(w, r)
+	})
 	http.HandleFunc("/last-updated", func(w http.ResponseWriter, r *http.Request) {
 		lastUpdatedHandler(db, w, r)
 	})

--- a/static/index.html
+++ b/static/index.html
@@ -5,8 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PastPath</title>
     <link rel="icon" href="static/favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" href="/static/styles.css">
+    <link rel="stylesheet" href="static/styles.css">
     <script src="static/script.js" defer></script>
+    <link rel="search" type="application/opensearchdescription+xml" href="static/opensearch.xml" title="pastpath">
 </head>
 
 <body>

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -3,11 +3,11 @@
     <ShortName>pastpath</ShortName>
     <Description>The greatest search engine for browser history</Description>
     <Tags>web</Tags>
-    <Contact>email@example.com</Contact>
+    <Contact>youremail@example.com</Contact>
     <Url type="text/html" template="http://www.localhost:10000/redirect?term={searchTerms}"></Url>
     <Url type="application/x-suggestions+json"
          template="http://www.localhost:10000/opensearch?term={searchTerms}"></Url>
-    <Image width="16" height="16" type="image/x-icon">http://www.example.com/favicon.ico</Image>
+    <Image width="16" height="16" type="image/x-icon">static/favicon.ico</Image>
     <InputEncoding>UTF-8</InputEncoding>
     <OutputEncoding>UTF-8</OutputEncoding>
 </OpenSearchDescription>

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+    <ShortName>pastpath</ShortName>
+    <Description>The greatest search engine for browser history</Description>
+    <Tags>web</Tags>
+    <Contact>email@example.com</Contact>
+    <Url type="text/html" template="http://www.localhost:8080/redirect?term={searchTerms}"></Url>
+    <Url type="application/x-suggestions+json"
+         template="http://www.localhost:8080/opensearch?term={searchTerms}"></Url>
+    <Image width="16" height="16" type="image/x-icon">http://www.example.com/favicon.ico</Image>
+    <InputEncoding>UTF-8</InputEncoding>
+    <OutputEncoding>UTF-8</OutputEncoding>
+</OpenSearchDescription>

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -4,9 +4,9 @@
     <Description>The greatest search engine for browser history</Description>
     <Tags>web</Tags>
     <Contact>email@example.com</Contact>
-    <Url type="text/html" template="http://www.localhost:8080/redirect?term={searchTerms}"></Url>
+    <Url type="text/html" template="http://www.localhost:10000/redirect?term={searchTerms}"></Url>
     <Url type="application/x-suggestions+json"
-         template="http://www.localhost:8080/opensearch?term={searchTerms}"></Url>
+         template="http://www.localhost:10000/opensearch?term={searchTerms}"></Url>
     <Image width="16" height="16" type="image/x-icon">http://www.example.com/favicon.ico</Image>
     <InputEncoding>UTF-8</InputEncoding>
     <OutputEncoding>UTF-8</OutputEncoding>


### PR DESCRIPTION
First attempt for enabling open search. It currently only works for Firefox.

Go localhost:1000, add search bar in top right corner and set pastpath to default.

Now you can get suggestions. It shows up as "title (url)". On enter redirect to url. if url is not there, redirect to google search.

Experience is not as good and rich as pastpath ui. 

Apparently opensearch supports description and url, but it did not work out of the box.
