### PR TITLE
Improve search performance

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -58,7 +58,7 @@ class SearchManager {
     setupSearchInput() {
         const debouncedSearch = debounce((event) => {
             this.handleSearchInput(event.target.value);
-        }, 50);
+        }, 250);
 
         this.searchBox.addEventListener('input', debouncedSearch);
     }


### PR DESCRIPTION
Introduce cache table to remove computation for https replacement and latest title at run time. Also increase debounce.

This will leave a ~1 sec each update cycle where data is not available, but it seems reasonable to cut down query time around 50-100%.